### PR TITLE
Changed plugin path and endpoint hook to be compatible with WP-API 2.0 alpha

### DIFF
--- a/bp-api.php
+++ b/bp-api.php
@@ -105,7 +105,7 @@ if ( !class_exists( 'BuddyPress_API' ) ) :
 			}
 
 			// is JSON API plugin active? If not, throw a notice and deactivate
-			if ( ! in_array( 'json-rest-api/plugin.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
+			if ( ! in_array( 'WP-API-develop/plugin.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) {
 				add_action( 'all_admin_notices', array( $this, 'bp_api_wp_api_required' ) );
 				return;
 			}
@@ -129,7 +129,7 @@ if ( !class_exists( 'BuddyPress_API' ) ) :
 				include_once( dirname( __FILE__ ) . '/endpoints/bp-api-xprofile.php' );
 			}
 
-			add_action( 'wp_json_server_before_serve', array( $this, 'create_bp_endpoints' ), 0 );
+			add_action( 'wp_json_init', array( $this, 'create_bp_endpoints' ), 0 );
 		}
 
 


### PR DESCRIPTION
Changed plugin path from "json-rest-api/plugin.php" to "WP-API-develop/plugin.php", so when it checks if the WP-API plugin is activated, it's looking in the right spot. This will need to be updated when 2.0 is released.

Changed "wp_json_server_before_serve" to "wp_json_init" to match the recent naming change in WP-API 2.0 alpha.